### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug Report
+description: Report bugs or issues.
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to fill out this bug report! The more info you provide, the more we can help you. If you are a [Frog Sponsor](https://github.com/sponsors/wevm?metadata_campaign=gh_issue), your issues are prioritized.
+
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: Clear and concise description of what the bug. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      placeholder: I am doing… What I expect is… What actually happening is…
+    validations:
+      required: true
+
+  - type: input
+    id: reproduction
+    attributes:
+      label: Link to Minimal Reproducible Example
+      description: "Please provide a link that can reproduce the problem: [by bootstrapping with cli](https://frog.fm/getting-started#bootstrap-via-cli) for runtime issues or [TypeScript Playground](https://www.typescriptlang.org/play) for type issues. For most issues, you will likely get asked to provide a minimal reproducible example so why not add one now :) If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a \"needs reproduction\" label."
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Steps or code snippets to reproduce the behavior.
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: Frog Version
+      description: What version of Frog are you using?
+      placeholder: x.y.z
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: TypeScript Version
+      description: What version of TypeScript are you using? Frog requires `typescript@>=5.0.4`.
+      placeholder: x.y.z
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Check existing issues
+      description: By submitting this issue, you checked there isn't [already an issue](https://github.com/wevm/frog/issues) for this bug.
+      options:
+        - label: I checked there isn't [already an issue](https://github.com/wevm/frog/issues) for the bug I encountered.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: Anything that will give us more context about the issue you are encountering.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Get Help
+    url: https://github.com/wevm/frog/discussions/new?category=q-a
+    about: Ask a question and discuss with other community members.
+
+  - name: Feature Request
+    url: https://github.com/wevm/frog/discussions/new?category=ideas
+    about: Request features or brainstorm ideas for new functionality.

--- a/.github/workflows/label-issue.yml
+++ b/.github/workflows/label-issue.yml
@@ -1,0 +1,18 @@
+name: Label Issue
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  reply-labeled:
+    runs-on: ubuntu-latest
+    steps:
+      - name: needs reproduction
+        if: github.event.label.name == 'needs reproduction'
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'create-comment'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using [cli](https://frog.fm/getting-started#bootstrap-via-cli) for runtime issues or [TypeScript Playground](https://www.typescriptlang.org/play) for type issues.


### PR DESCRIPTION
I've removed the "auto-close after 3 days of no reproduction example" and "auto-close after 14 days of inactivity" as the repo is pretty new and doesn't suffer yet from issue spam.