### PR TITLE
fix(vercel-serverless): Modified filepath

### DIFF
--- a/site/pages/platforms/vercel.mdx
+++ b/site/pages/platforms/vercel.mdx
@@ -38,7 +38,7 @@ npm install vercel --save-dev
 
 Next, scaffold your frame:
 
-```tsx twoslash [src/index.tsx]
+```tsx twoslash [api/index.tsx]
 // @noErrors
 /** @jsxImportSource frog/jsx */
 // ---cut---
@@ -87,7 +87,7 @@ It is recommended to use your own Hub API URL in production.
 
 After that, we will append Vercel handlers to the file.
 
-```tsx twoslash [src/index.tsx]
+```tsx twoslash [api/index.tsx]
 // @noErrors
 /** @jsxImportSource frog/jsx */
 // ---cut---
@@ -178,7 +178,7 @@ they will be redirected to the `/` path.
 
 [Read more on Browser Redirects](/concepts/browser-redirects)
 
-```tsx twoslash [src/index.tsx]
+```tsx twoslash [api/index.tsx]
 // @noErrors
 /** @jsxImportSource frog/jsx */
 // ---cut---


### PR DESCRIPTION
https://frog.fm/platforms/vercel#bonus-browser-redirects mentions the filepath for vercel serverless as src/index.tsx which is incorrect. It should be api/index.tsx which `create-frog` also correctly bootstraps to.