### PR TITLE
fix: export FrameIntent(s) types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,11 @@ export type {
   FrameContext,
   TransactionContext,
 } from './types/context.js'
-export type { FrameResponse } from './types/frame.js'
+export type {
+  FrameResponse,
+  FrameIntent,
+  FrameIntents,
+} from './types/frame.js'
 export type {
   TransactionResponse,
   ContractTransactionParameters,


### PR DESCRIPTION
hi there, would love to export `FrameIntent` and `FrameIntents` types to aid dev of our project