### PR TITLE
Fix image size limit

### DIFF
--- a/.changeset/forty-cups-lie.md
+++ b/.changeset/forty-cups-lie.md
@@ -1,0 +1,5 @@
+---
+"frog": patch
+---
+
+Corrected image size limit

--- a/src/dev/components/Data.tsx
+++ b/src/dev/components/Data.tsx
@@ -14,7 +14,7 @@ export function Data() {
             postUrl: 256,
             inputText: 32,
             state: 4_096,
-            image: 10_000,
+            image: 10_485_760,
           }
           const postUrlTooLong = frame.postUrl.length > limits.postUrl
           const inputTextTooLong = frame.input?.text

--- a/src/dev/components/Data.tsx
+++ b/src/dev/components/Data.tsx
@@ -14,7 +14,7 @@ export function Data() {
             postUrl: 256,
             inputText: 32,
             state: 4_096,
-            image: 256,
+            image: 10_000,
           }
           const postUrlTooLong = frame.postUrl.length > limits.postUrl
           const inputTextTooLong = frame.input?.text


### PR DESCRIPTION
Currently the frog debugger shows an error if an image is >256kb, but the [Farcaster docs](https://docs.farcaster.xyz/reference/frames/spec#images) say an image can be up to 10mb

<img width="566" alt="image" src="https://github.com/wevm/frog/assets/35093316/ee5643c9-6bb1-41a8-87c8-d726ed97fbdc">