### PR TITLE
Update transaction.ts to support Base Sepolia

### DIFF
--- a/.changeset/cyan-rats-work.md
+++ b/.changeset/cyan-rats-work.md
@@ -2,4 +2,4 @@
 "frog": patch
 ---
 
-Update transaction.ts to support Base Sepolia
+Added support for Base Sepolia transactions

--- a/.changeset/cyan-rats-work.md
+++ b/.changeset/cyan-rats-work.md
@@ -1,5 +1,5 @@
 ---
-"frog": minor
+"frog": patch
 ---
 
 Update transaction.ts to support Base Sepolia

--- a/.changeset/cyan-rats-work.md
+++ b/.changeset/cyan-rats-work.md
@@ -1,0 +1,5 @@
+---
+"frog": minor
+---
+
+Update transaction.ts to support Base Sepolia

--- a/.changeset/sour-snails-study.md
+++ b/.changeset/sour-snails-study.md
@@ -1,5 +1,0 @@
----
-"frog": major
----
-
-Update transaction.ts to support Base Sepolia

--- a/.changeset/sour-snails-study.md
+++ b/.changeset/sour-snails-study.md
@@ -1,0 +1,5 @@
+---
+"frog": major
+---
+
+Update transaction.ts to support Base Sepolia

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -19,7 +19,7 @@ export type ChainNamespace = 'eip155'
  * - 8453: Base
  * - 7777777: Zora
  */
-export type ChainIdEip155 = 10 | 8453 | 7777777
+export type ChainIdEip155 = 10 | 8453 | 84532 | 7777777
 
 export type TransactionParameters = {
   /** A CAIP-2 Chain ID to identify the transaction network. */


### PR DESCRIPTION
Now that Warpcast supports Base Sepolia, we should permit transaction attempts through chain id 84532.