### PR TITLE
Added `attribution` parameter to transactions

### DIFF
--- a/.changeset/five-kids-rush.md
+++ b/.changeset/five-kids-rush.md
@@ -1,0 +1,5 @@
+---
+"frog": minor
+---
+
+Add `attribution` parameter to transactions

--- a/.changeset/five-kids-rush.md
+++ b/.changeset/five-kids-rush.md
@@ -2,4 +2,4 @@
 "frog": minor
 ---
 
-Add `attribution` parameter to transactions
+Added `attribution` parameter to transaction response

--- a/site/pages/reference/frog-transaction-response.mdx
+++ b/site/pages/reference/frog-transaction-response.mdx
@@ -317,10 +317,10 @@ export const app = new Frog()
 app.transaction('/mint', (c) => {
   return c.contract({ 
     abi, 
-    attribution: false, // [!code focus]
     chainId: 'eip155:10', 
     functionName: 'mint', 
     to: '0xd2135CfB216b74109775236E36d4b433F1DF507B', 
+    attribution: false, // [!code focus]
   }) 
 })
 ```

--- a/site/pages/reference/frog-transaction-response.mdx
+++ b/site/pages/reference/frog-transaction-response.mdx
@@ -144,6 +144,28 @@ app.transaction('/send-ether', (c) => {
 })
 ```
 
+### attribution (optional)
+
+- **Type:** `boolean`
+
+Optionally omit the client calldata attribution suffix.
+
+```tsx twoslash
+// @noErrors
+import { Frog, parseEther } from 'frog'
+ 
+export const app = new Frog()
+
+app.transaction('/send-ether', (c) => {
+  return c.send({ 
+    chainId: 'eip155:10',
+    to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+    abi, 
+    attribution: false, // [!code focus]
+  }) 
+})
+```
+
 ### data (optional)
 
 - **Type:** `Hex`
@@ -279,6 +301,30 @@ app.transaction('/mint', (c) => {
 })
 ```
 
+
+### attribution (optional)
+
+- **Type:** `boolean`
+
+Optionally omit the client calldata attribution suffix.
+
+```tsx twoslash
+// @noErrors
+import { Frog, parseEther } from 'frog'
+ 
+export const app = new Frog()
+
+app.transaction('/mint', (c) => {
+  return c.contract({ 
+    abi, 
+    attribution: false, // [!code focus]
+    chainId: 'eip155:10', 
+    functionName: 'mint', 
+    to: '0xd2135CfB216b74109775236E36d4b433F1DF507B', 
+  }) 
+})
+```
+
 ### value (optional)
 
 - **Type:** `Address`
@@ -373,6 +419,31 @@ app.transaction('/raw-send', (c) => {
       to: '0xd2135CfB216b74109775236E36d4b433F1DF507B', // [!code focus] 
       value: 1n, // [!code focus] 
     }, // [!code focus] 
+  }) 
+})
+```
+
+### attribution (optional)
+
+- **Type:** `boolean`
+
+Optionally omit the client calldata attribution suffix.
+
+```tsx twoslash
+// @noErrors
+import { Frog, parseEther } from 'frog'
+
+export const app = new Frog()
+
+app.transaction('/raw-send', (c) => {
+  return c.res({ 
+    chainId: 'eip155:10',
+    method: 'eth_sendTransaction',
+    params: { 
+      to: '0xd2135CfB216b74109775236E36d4b433F1DF507B', 
+      value: 1n,
+    }, 
+    attribution: false, // [!code focus]
   }) 
 })
 ```

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -24,9 +24,11 @@ export type ChainIdEip155 = 10 | 8453 | 84532 | 7777777
 export type TransactionParameters = {
   /** A CAIP-2 Chain ID to identify the transaction network. */
   chainId: `${ChainNamespace}:${ChainIdEip155}`
+  /** Optionally omit the client calldata attribution suffix */
+  attribution?: boolean
 } & EthSendTransactionSchema<bigint>
 
-export type TransactionResponse = Pick<TransactionParameters, 'chainId'> &
+export type TransactionResponse = Pick<TransactionParameters, 'chainId' | 'attribution'> &
   EthSendTransactionSchema
 
 export type EthSendTransactionSchema<quantity = string> = {
@@ -45,6 +47,8 @@ export type EthSendTransactionParameters<quantity = string> = {
   to: Hex
   /** Value to send with transaction (in wei). */
   value?: quantity
+  /** Optionally omit the client calldata attribution suffix */
+  attribution?: boolean
 }
 
 export type TransactionResponseFn<parameters> = (
@@ -79,6 +83,8 @@ export type ContractTransactionParameters<
   abi: abi
   /** Contract function arguments. */
   args?: (abi extends Abi ? UnionWiden<args> : never) | allArgs | undefined
+  /** Optionally omit the client calldata attribution suffix */
+  attribution?: boolean
   /** Contract function name to invoke. */
   functionName:
     | allFunctionNames // show all options

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -25,7 +25,7 @@ export type TransactionParameters = {
   /** A CAIP-2 Chain ID to identify the transaction network. */
   chainId: `${ChainNamespace}:${ChainIdEip155}`
   /** Optionally omit the client calldata attribution suffix */
-  attribution?: boolean
+  attribution?: boolean | undefined
 } & EthSendTransactionSchema<bigint>
 
 export type TransactionResponse = Pick<TransactionParameters, 'chainId' | 'attribution'> &
@@ -48,7 +48,7 @@ export type EthSendTransactionParameters<quantity = string> = {
   /** Value to send with transaction (in wei). */
   value?: quantity
   /** Optionally omit the client calldata attribution suffix */
-  attribution?: boolean
+  attribution?: boolean | undefined
 }
 
 export type TransactionResponseFn<parameters> = (
@@ -84,7 +84,7 @@ export type ContractTransactionParameters<
   /** Contract function arguments. */
   args?: (abi extends Abi ? UnionWiden<args> : never) | allArgs | undefined
   /** Optionally omit the client calldata attribution suffix */
-  attribution?: boolean
+  attribution?: boolean | undefined
   /** Contract function name to invoke. */
   functionName:
     | allFunctionNames // show all options

--- a/src/utils/getTransactionContext.ts
+++ b/src/utils/getTransactionContext.ts
@@ -66,7 +66,7 @@ export function getTransactionContext<
       buttonIndex: frameData?.buttonIndex,
       buttonValue,
       contract(parameters) {
-        const { abi, chainId, functionName, to, args, value } = parameters
+        const { abi, chainId, functionName, to, args, value, attribution } = parameters
 
         const abiItem = getAbiItem({
           abi: abi,
@@ -81,6 +81,7 @@ export function getTransactionContext<
 
         return this.send({
           abi: [abiItem, ...abiErrorItems],
+          attribution,
           chainId,
           data: encodeFunctionData({
             abi,
@@ -99,9 +100,10 @@ export function getTransactionContext<
       previousState,
       req,
       res(parameters) {
-        const { chainId, method, params } = parameters
+        const { attribution, chainId, method, params } = parameters
         const { abi, data, to, value } = params
         const response: TransactionResponse = {
+          attribution,
           chainId,
           method,
           params: {
@@ -115,6 +117,7 @@ export function getTransactionContext<
       },
       send(parameters) {
         return this.res({
+          attribution: parameters.attribution,
           chainId: parameters.chainId,
           method: 'eth_sendTransaction',
           params: parameters,


### PR DESCRIPTION
This fixes errors related to parsing token approvals in some wallets.

Related 
- https://warpcast.com/horsefacts.eth/0xfc6b312e
- https://warpcast.com/undefined/0x054af34f
