### PR TITLE
fix(devtools): don't set bg color to `#000`

### DIFF
--- a/.changeset/fuzzy-kangaroos-march.md
+++ b/.changeset/fuzzy-kangaroos-march.md
@@ -1,0 +1,5 @@
+---
+"frog": patch
+---
+
+Fixed dark background set on devtools which resulted in bad UI for browsers with ligh-mode scheme preference.

--- a/src/dev/devtools.tsx
+++ b/src/dev/devtools.tsx
@@ -219,7 +219,7 @@ export function routes(
                 href={`${assetsPath}/assets/icon.png`}
               />
             </head>
-            <body style={{ backgroundColor: '#000' }}>
+            <body>
               <div id="root" />
               <script
                 id="__FROG_DATA__"


### PR DESCRIPTION
Background color is already set on `html` tag and equals to `--background-200`.

Having `#000` color set breaks devtools styling in light mode.