### PR TITLE
Added middleware examples for modifying responses

### DIFF
--- a/site/pages/concepts/middleware.mdx
+++ b/site/pages/concepts/middleware.mdx
@@ -138,6 +138,7 @@ You can write your own Frog middleware. This is great if you want to share commo
 ```tsx twoslash
 // @noErrors
 import { Frog } from 'frog'
+ 
 export const app = new Frog()
 
 // Custom logger // [!code focus]
@@ -166,6 +167,7 @@ You can also write a custom middleware to add additional params to Frog's Transa
 ```tsx twoslash
 // @noErrors
 import { Frog } from 'frog'
+ 
 export const app = new Frog()
 
 app.transaction( // [!code focus]
@@ -193,6 +195,7 @@ You can write a custom middleware to modify the response to add extra [open-fram
 ```tsx twoslash
 // @noErrors
 import { Frog } from 'frog'
+ 
 export const app = new Frog()
 
 app.use(async (c, next) => { // [!code focus]

--- a/site/pages/concepts/middleware.mdx
+++ b/site/pages/concepts/middleware.mdx
@@ -136,8 +136,9 @@ It is recommended to use your own API Key in production. [See more](https://neyn
 You can write your own Frog middleware. This is great if you want to share common logic across or frames or if you are developing a SDK for Frog users to hook into their frames.
 
 ```tsx twoslash
-import { Frog } from 'frog'
 // @noErrors
+import { Frog } from 'frog'
+
 export const app = new Frog()
 
 // Custom logger // [!code focus]
@@ -164,8 +165,9 @@ app.frame('/foo/bar', (c) => {/* ... */})
 You can also write a custom middleware to add additional params to Frog's TransactionResponse (mimics [`Transaction Specs API`](https://warpcast.notion.site/Frame-Transactions-Public-9d9f9f4f527249519a41bd8d16165f73#8235c261091e4499b417e71dd1753e05)).
 
 ```tsx twoslash
-import { Frog } from 'frog'
 // @noErrors
+import { Frog } from 'frog'
+
 export const app = new Frog()
 
 app.transaction( // [!code focus]
@@ -191,8 +193,9 @@ You can write a custom middleware to modify the response to add extra [open-fram
 > Since the Frames Spec is still new (launched on 1/26/24) and hasn't hit a stable v1 yet (current vNext), we don't want to introduce additional standards to Frog that might conflict with or diverge from what the Farcaster team and community has planned. In addition, the vast majority of Frame usage at the moment is via Warpcast (and Farcaster) so we want to make sure Frog serves that main audience first.
 
 ```tsx twoslash
-import { Frog } from 'frog'
 // @noErrors
+import { Frog } from 'frog'
+
 export const app = new Frog()
 
 app.use(async (c, next) => { // [!code focus]

--- a/site/pages/concepts/middleware.mdx
+++ b/site/pages/concepts/middleware.mdx
@@ -138,7 +138,6 @@ You can write your own Frog middleware. This is great if you want to share commo
 ```tsx twoslash
 // @noErrors
 import { Frog } from 'frog'
-
 export const app = new Frog()
 
 // Custom logger // [!code focus]
@@ -167,7 +166,6 @@ You can also write a custom middleware to add additional params to Frog's Transa
 ```tsx twoslash
 // @noErrors
 import { Frog } from 'frog'
-
 export const app = new Frog()
 
 app.transaction( // [!code focus]
@@ -195,7 +193,6 @@ You can write a custom middleware to modify the response to add extra [open-fram
 ```tsx twoslash
 // @noErrors
 import { Frog } from 'frog'
-
 export const app = new Frog()
 
 app.use(async (c, next) => { // [!code focus]

--- a/site/pages/concepts/middleware.mdx
+++ b/site/pages/concepts/middleware.mdx
@@ -136,9 +136,8 @@ It is recommended to use your own API Key in production. [See more](https://neyn
 You can write your own Frog middleware. This is great if you want to share common logic across or frames or if you are developing a SDK for Frog users to hook into their frames.
 
 ```tsx twoslash
-// @noErrors
 import { Frog } from 'frog'
- 
+// @noErrors
 export const app = new Frog()
 
 // Custom logger // [!code focus]
@@ -159,6 +158,59 @@ app.frame('/foo', (c) => {/* ... */})
 
 app.frame('/foo/bar', (c) => {/* ... */})
 ```
+
+### Example: TransactionResponse
+
+You can also write a custom middleware to add additional params to Frog's TransactionResponse (mimics [`Transaction Specs API`](https://warpcast.notion.site/Frame-Transactions-Public-9d9f9f4f527249519a41bd8d16165f73#8235c261091e4499b417e71dd1753e05)).
+
+```tsx twoslash
+import { Frog } from 'frog'
+// @noErrors
+export const app = new Frog()
+
+app.transaction( // [!code focus]
+  '/mint', // [!code focus]
+  async (c, next) => { // [!code focus]
+    await next(); // [!code focus]
+    const txParams = await c.res.json(); // [!code focus]
+    txParams.attribution = false; // [!code focus]
+    c.res = new Response(JSON.stringify(txParams), { // [!code focus]
+      headers: { // [!code focus]
+        'Content-Type': 'application/json', // [!code focus]
+      }, // [!code focus]
+    }); // [!code focus]
+  }, // [!code focus]
+  (c) => {/* ... */} // [!code focus]
+); // [!code focus]
+```
+
+### Example: Modifying the FrameResponse
+
+You can write a custom middleware to modify the response to add extra [open-frames metadata](https://github.com/open-frames/standard) to fit your needs.
+
+> Since the Frames Spec is still new (launched on 1/26/24) and hasn't hit a stable v1 yet (current vNext), we don't want to introduce additional standards to Frog that might conflict with or diverge from what the Farcaster team and community has planned. In addition, the vast majority of Frame usage at the moment is via Warpcast (and Farcaster) so we want to make sure Frog serves that main audience first.
+
+```tsx twoslash
+import { Frog } from 'frog'
+// @noErrors
+export const app = new Frog()
+
+app.use(async (c, next) => { // [!code focus]
+  await next(); // [!code focus]
+  const isFrame = c.res.headers.get('content-type')?.includes('html'); // [!code focus]
+  if (isFrame) { // [!code focus]
+    let html = await c.res.text(); // [!code focus]
+    const metaTag = '<meta property="of:accepts:xmtp" content="2024-02-01" />'; // [!code focus]
+    html = html.replace(/(<head>)/i, `$1${metaTag}`); // [!code focus]
+    c.res = new Response(html, { // [!code focus]
+      headers: { // [!code focus]
+        'content-type': 'text/html', // [!code focus]
+      }, // [!code focus]
+    }); // [!code focus]
+  } // [!code focus]
+}); // [!code focus]
+```
+
 
 ## Community Middleware
 

--- a/site/pages/reference/frog-transaction-response.mdx
+++ b/site/pages/reference/frog-transaction-response.mdx
@@ -8,6 +8,8 @@ There are three types of responses:
 - [Contract Transaction (`c.contract`)](#contract-transaction-ccontract): Convinience method to **invoke a contract function** (with inferred types & automatic encoding).
 - [Raw Transaction (`c.res`)](#raw-transaction-cres): Low-level method to **send raw transaction** (mimics the [Transaction Spec API](https://warpcast.notion.site/Frame-Transactions-Public-Draft-v2-9d9f9f4f527249519a41bd8d16165f73?pvs=4)).
 
+If you want to pass additional parameters to the `TransactionResponse`, refer to the [example of transaction middleware](/concepts/middleware#example-transactionresponse).
+
 ```tsx twoslash
 // @noErrors
 import { Frog, parseEther } from 'frog'
@@ -376,3 +378,4 @@ app.transaction('/raw-send', (c) => {
   }) 
 })
 ```
+import { request } from "http"


### PR DESCRIPTION
An extension PR of https://github.com/wevm/frog/pull/172

related - https://github.com/wevm/frog/discussions/51

> I believe it's also worth noting in https://frog.fm/concepts/transactions and set `attribution: false` everywhere with a note that when [MetaMask/metamask-extension#23527](https://github.com/MetaMask/metamask-extension/pull/23527) is merged, this will be no longer needed.

Instead of adding something that might be deprecated in the future, I updated the docs so users can create their own middleware to customize the response to fit their needs.

