### PR TITLE
fix: `getFrameContext` `origin` usage

### DIFF
--- a/.changeset/proud-hounds-double.md
+++ b/.changeset/proud-hounds-double.md
@@ -1,0 +1,5 @@
+---
+"frog": patch
+---
+
+Fixed incorrect `origin` propagation in `getFrameContext` that made NGINX reverse-proxy frog setups to have origin set to `127.0.0.1`.

--- a/src/frog-base.tsx
+++ b/src/frog-base.tsx
@@ -302,7 +302,7 @@ export class FrogBase<
         origin,
       })
 
-      if (context.url !== parsePath(c.req.url)) return c.redirect(context.url)
+      if (context.url.endsWith('/')) return c.redirect(context.url.slice(0, -1))
 
       const response = await handler(context)
       if (response instanceof Response) return response

--- a/src/utils/getFrameContext.ts
+++ b/src/utils/getFrameContext.ts
@@ -54,7 +54,8 @@ export function getFrameContext<
   // If the user has clicked a reset button, we want to set the URL back to the
   // initial URL.
   const url =
-    (reset ? `${origin}${initialPath}` : undefined) || parsePath(context.url)
+    (reset ? `${origin}${initialPath}` : undefined) ||
+    parsePath(`${origin}${context.req.path}?${context.req.query()}`)
 
   let previousState = (() => {
     if (context.status === 'initial') return parameters.initialState


### PR DESCRIPTION
Fixed incorrect `origin` propagation in `getFrameContext` that made NGINX reverse-proxy frog setups to have origin set to `127.0.0.1`.