### PR TITLE
feat: add xmtp meta tag

### DIFF
--- a/src/frog-base.tsx
+++ b/src/frog-base.tsx
@@ -424,6 +424,7 @@ export class FrogBase<
                 property="fc:frame:image:aspect_ratio"
                 content={imageAspectRatio}
               />
+              <meta property="of:accepts:xmtp" content="2024-02-01" />
               <meta property="fc:frame:image" content={imageUrl} />
               <meta property="og:image" content={ogImageUrl ?? imageUrl} />
               <meta property="og:title" content={title} />


### PR DESCRIPTION
add in the `frog-base.tsx` file the xmtp meta tag

```
<meta property="of:accepts:xmtp" content="2024-02-01" />
```

that allows xmtp clients to display the frame correctly.