### PR TITLE
Added attribution option to transaction parameters

### DIFF
--- a/.changeset/nervous-news-flow.md
+++ b/.changeset/nervous-news-flow.md
@@ -1,5 +1,5 @@
 ---
-"frog": minor
+"frog": patch
 ---
 
 Added attribution option to transaction parameters

--- a/.changeset/nervous-news-flow.md
+++ b/.changeset/nervous-news-flow.md
@@ -1,0 +1,5 @@
+---
+"frog": minor
+---
+
+Added attribution option to transaction parameters

--- a/site/pages/reference/frog-transaction-response.mdx
+++ b/site/pages/reference/frog-transaction-response.mdx
@@ -350,7 +350,6 @@ app.transaction('/mint', (c) => {
 })
 ```
 
-
 ## Raw Transaction (`c.res`)
 
 ### chainId

--- a/site/pages/reference/frog-transaction-response.mdx
+++ b/site/pages/reference/frog-transaction-response.mdx
@@ -144,6 +144,29 @@ app.transaction('/send-ether', (c) => {
 })
 ```
 
+### attribution (optional)
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Optionally include the client [calldata suffix](https://warpcast.notion.site/Frame-Transactions-Public-9d9f9f4f527249519a41bd8d16165f73#c1c3182208ce4ae4a7ffa72129b9795a)
+
+```tsx twoslash
+// @noErrors
+import { Frog, parseEther } from 'frog'
+
+export const app = new Frog()
+
+app.transaction('/send-ether', (c) => {
+  return c.send({ 
+    chainId: 'eip155:10',
+    to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+    abi, 
+    attribution: true, // [!code focus]
+  }) 
+})
+```
+
 ### data (optional)
 
 - **Type:** `Hex`
@@ -279,6 +302,30 @@ app.transaction('/mint', (c) => {
 })
 ```
 
+### attribution (optional)
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Optionally include the client [calldata suffix](https://warpcast.notion.site/Frame-Transactions-Public-9d9f9f4f527249519a41bd8d16165f73#c1c3182208ce4ae4a7ffa72129b9795a)
+
+```tsx twoslash
+// @noErrors
+import { Frog, parseEther } from 'frog'
+
+export const app = new Frog()
+
+app.transaction('/mint', (c) => {
+  return c.contract({ 
+    abi, 
+    chainId: 'eip155:10', 
+    functionName: 'mint', 
+    to: '0xd2135CfB216b74109775236E36d4b433F1DF507B', 
+    attribution: true, // [!code focus]
+  }) 
+})
+```
+
 ### value (optional)
 
 - **Type:** `Address`
@@ -302,6 +349,7 @@ app.transaction('/mint', (c) => {
   }) 
 })
 ```
+
 
 ## Raw Transaction (`c.res`)
 
@@ -373,6 +421,32 @@ app.transaction('/raw-send', (c) => {
       to: '0xd2135CfB216b74109775236E36d4b433F1DF507B', // [!code focus] 
       value: 1n, // [!code focus] 
     }, // [!code focus] 
+  }) 
+})
+```
+
+### attribution (optional)
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Optionally include the client [calldata suffix](https://warpcast.notion.site/Frame-Transactions-Public-9d9f9f4f527249519a41bd8d16165f73#c1c3182208ce4ae4a7ffa72129b9795a)
+
+```tsx twoslash
+// @noErrors
+import { Frog, parseEther } from 'frog'
+
+export const app = new Frog()
+
+app.transaction('/raw-send', (c) => {
+  return c.res({ 
+    chainId: 'eip155:10',
+    method: 'eth_sendTransaction',
+    params: { 
+      to: '0xd2135CfB216b74109775236E36d4b433F1DF507B', 
+      value: 1n,
+    }, 
+    attribution: true, // [!code focus]
   }) 
 })
 ```

--- a/site/pages/reference/frog-transaction-response.mdx
+++ b/site/pages/reference/frog-transaction-response.mdx
@@ -149,7 +149,7 @@ app.transaction('/send-ether', (c) => {
 - **Type:** `boolean`
 - **Default:** `false`
 
-Optionally include the client [calldata suffix](https://warpcast.notion.site/Frame-Transactions-Public-9d9f9f4f527249519a41bd8d16165f73#c1c3182208ce4ae4a7ffa72129b9795a)
+Includes client [calldata suffix](https://warpcast.notion.site/Frame-Transactions-Public-9d9f9f4f527249519a41bd8d16165f73#c1c3182208ce4ae4a7ffa72129b9795a)
 
 ```tsx twoslash
 // @noErrors
@@ -307,7 +307,7 @@ app.transaction('/mint', (c) => {
 - **Type:** `boolean`
 - **Default:** `false`
 
-Optionally include the client [calldata suffix](https://warpcast.notion.site/Frame-Transactions-Public-9d9f9f4f527249519a41bd8d16165f73#c1c3182208ce4ae4a7ffa72129b9795a)
+Includes client [calldata suffix](https://warpcast.notion.site/Frame-Transactions-Public-9d9f9f4f527249519a41bd8d16165f73#c1c3182208ce4ae4a7ffa72129b9795a)
 
 ```tsx twoslash
 // @noErrors
@@ -429,7 +429,7 @@ app.transaction('/raw-send', (c) => {
 - **Type:** `boolean`
 - **Default:** `false`
 
-Optionally include the client [calldata suffix](https://warpcast.notion.site/Frame-Transactions-Public-9d9f9f4f527249519a41bd8d16165f73#c1c3182208ce4ae4a7ffa72129b9795a)
+Includes client [calldata suffix](https://warpcast.notion.site/Frame-Transactions-Public-9d9f9f4f527249519a41bd8d16165f73#c1c3182208ce4ae4a7ffa72129b9795a)
 
 ```tsx twoslash
 // @noErrors

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -24,7 +24,7 @@ export type ChainIdEip155 = 10 | 8453 | 84532 | 7777777
 export type TransactionParameters = {
   /** A CAIP-2 Chain ID to identify the transaction network. */
   chainId: `${ChainNamespace}:${ChainIdEip155}`
-  /** Optionally include the client calldata attribution suffix */
+  /** Includes client calldata attribution suffix */
   attribution?: boolean | undefined
 } & EthSendTransactionSchema<bigint>
 
@@ -44,7 +44,10 @@ export type EthSendTransactionSchema<quantity = string> = {
 export type EthSendTransactionParameters<quantity = string> = {
   /** Contract ABI. */
   abi?: Abi | undefined
-  /** Client calldata attribution suffix (default false) */
+  /**
+   * Client calldata attribution suffix
+   * @default false
+   */
   attribution?: boolean | undefined
   /** Transaction calldata. */
   data?: Hex | undefined
@@ -86,7 +89,7 @@ export type ContractTransactionParameters<
   abi: abi
   /** Contract function arguments. */
   args?: (abi extends Abi ? UnionWiden<args> : never) | allArgs | undefined
-  /** Optionally include the client calldata attribution suffix */
+  /** Includes client calldata attribution suffix */
   attribution?: boolean | undefined
   /** Contract function name to invoke. */
   functionName:

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -24,9 +24,14 @@ export type ChainIdEip155 = 10 | 8453 | 84532 | 7777777
 export type TransactionParameters = {
   /** A CAIP-2 Chain ID to identify the transaction network. */
   chainId: `${ChainNamespace}:${ChainIdEip155}`
+  /** Optionally include the client calldata attribution suffix */
+  attribution?: boolean | undefined
 } & EthSendTransactionSchema<bigint>
 
-export type TransactionResponse = Pick<TransactionParameters, 'chainId'> &
+export type TransactionResponse = Pick<
+  TransactionParameters,
+  'chainId' | 'attribution'
+> &
   EthSendTransactionSchema
 
 export type EthSendTransactionSchema<quantity = string> = {
@@ -39,6 +44,8 @@ export type EthSendTransactionSchema<quantity = string> = {
 export type EthSendTransactionParameters<quantity = string> = {
   /** Contract ABI. */
   abi?: Abi | undefined
+  /** Client calldata attribution suffix (default false) */
+  attribution?: boolean | undefined
   /** Transaction calldata. */
   data?: Hex | undefined
   /** Transaction target address. */
@@ -79,6 +86,8 @@ export type ContractTransactionParameters<
   abi: abi
   /** Contract function arguments. */
   args?: (abi extends Abi ? UnionWiden<args> : never) | allArgs | undefined
+  /** Optionally include the client calldata attribution suffix */
+  attribution?: boolean | undefined
   /** Contract function name to invoke. */
   functionName:
     | allFunctionNames // show all options

--- a/src/utils/getTransactionContext.ts
+++ b/src/utils/getTransactionContext.ts
@@ -66,7 +66,8 @@ export function getTransactionContext<
       buttonIndex: frameData?.buttonIndex,
       buttonValue,
       contract(parameters) {
-        const { abi, chainId, functionName, to, args, value } = parameters
+        const { abi, chainId, functionName, to, args, attribution, value } =
+          parameters
 
         const abiItem = getAbiItem({
           abi: abi,
@@ -81,6 +82,7 @@ export function getTransactionContext<
 
         return this.send({
           abi: [abiItem, ...abiErrorItems],
+          attribution,
           chainId,
           data: encodeFunctionData({
             abi,
@@ -99,9 +101,10 @@ export function getTransactionContext<
       previousState,
       req,
       res(parameters) {
-        const { chainId, method, params } = parameters
+        const { attribution, chainId, method, params } = parameters
         const { abi, data, to, value } = params
         const response: TransactionResponse = {
+          attribution,
           chainId,
           method,
           params: {
@@ -115,6 +118,7 @@ export function getTransactionContext<
       },
       send(parameters) {
         return this.res({
+          attribution: parameters.attribution ?? false,
           chainId: parameters.chainId,
           method: 'eth_sendTransaction',
           params: parameters,


### PR DESCRIPTION
Follow up of #172 and #177 

---

 [`Calling allowance calls within Desktop Metamask`](https://github.com/wevm/frog/pull/172#issuecomment-2012773361) fails, which would be fixed by https://github.com/MetaMask/metamask-extension/pull/23527.

However, that wouldn't solve the problem of sending ETH to a `contract address` using `eth_sendTransaction`.

Sending ETH to a contract address always reverts when `attribution` option is `true` or `undefined`.

@dalechyn suggested we should have `attribution` flag false by default, and let users include them if needed.

---

Below is an example Warpcast Simulation parameters when sending ETH to a contract address using `c.res` or `c.send`.

```ts
transaction": {
    "method": "eth_sendTransaction",
    "params": {
        "to": "0xeac856237a85b70338a32b55bf44b13ef1a7811d",
        "data": "0xfc000023c0",
        "value": "5000000000000000",
        "chainId": "8453",
        "from": "0x130946d8dF113e45f44e13575012D0cFF1E53e37"
    }
},
```

Related discord Conversation: https://discord.com/channels/1156791276818157609/1221669227182821406