### PR TITLE
feat: `format` to be `png` by default

### DIFF
--- a/.changeset/fast-cycles-jump.md
+++ b/.changeset/fast-cycles-jump.md
@@ -1,0 +1,5 @@
+---
+"frog": patch
+---
+
+Set `format` property to be `png` as warpcast does not support `svg+xml` content-type, which was the previously selected by default.

--- a/src/frog-base.tsx
+++ b/src/frog-base.tsx
@@ -318,7 +318,7 @@ export class FrogBase<
         const image_ = JSON.parse(lz.decompressFromEncodedURIComponent(image))
         return new ImageResponse(image_, {
           ...imageOptions,
-          format: 'png',
+          format: imageOptions?.format ?? 'png',
           fonts: await parseFonts(fonts),
           headers: imageOptions?.headers ?? headers,
         })

--- a/src/frog-base.tsx
+++ b/src/frog-base.tsx
@@ -318,6 +318,7 @@ export class FrogBase<
         const image_ = JSON.parse(lz.decompressFromEncodedURIComponent(image))
         return new ImageResponse(image_, {
           ...imageOptions,
+          format: 'png',
           fonts: await parseFonts(fonts),
           headers: imageOptions?.headers ?? headers,
         })


### PR DESCRIPTION
I've noticed that issue when I tried to debug the frame with Warpcast Validator.

The frame served in the `playground`, returned svg file as an image rather than a png file.
While that works in the debugger, it doesn't work in previews nor in the validator itself.

https://github.com/wevm/hono-og/blob/5cc0ddb25e4f8423276549cde6a4267607e7146c/src/response.ts#L23-L25

Since the check is against the `png` here, and unless a user passes a `format` property, it will always opt out to svg rendering.