### PR TITLE
fix: broken `<Button.Reset>` behaviour

### DIFF
--- a/.changeset/rude-dryers-jump.md
+++ b/.changeset/rude-dryers-jump.md
@@ -1,0 +1,5 @@
+---
+"frog": patch
+---
+
+Fixed broken `<Button.Reset>` behaviour.

--- a/src/utils/getFrameContext.ts
+++ b/src/utils/getFrameContext.ts
@@ -53,8 +53,7 @@ export function getFrameContext<
 
   // If the user has clicked a reset button, we want to set the URL back to the
   // initial URL.
-  const url =
-    (reset ? `${origin}${initialPath}` : undefined) || parsePath(context.url)
+  const url = parsePath(reset ? `${origin}${initialPath}` : context.url)
 
   let previousState = (() => {
     if (context.status === 'initial') return parameters.initialState


### PR DESCRIPTION
![Screenshot 2024-03-28 at 11 50 26](https://github.com/wevm/frog/assets/35642018/d289bd35-ce02-42ba-8e39-8a62e14dcdfb)

Reset redirects to origin + initialPath, and while initialPath is `/`, there is a redirect loop.

`parsePath` util ensures that the trailing slash is removed.