### PR TITLE
feat: refreshing images

### DIFF
--- a/.changeset/strong-laws-drive.md
+++ b/.changeset/strong-laws-drive.md
@@ -1,0 +1,5 @@
+---
+"frog": patch
+---
+
+Implemented image retrieval without search params for initial frame request.

--- a/playground/src/clock.tsx
+++ b/playground/src/clock.tsx
@@ -1,0 +1,17 @@
+import { Frog } from 'frog'
+import { Heading, VStack, vars } from './ui.js'
+
+export const app = new Frog({
+  ui: { vars },
+  headers: { 'cache-control': 'max-age=0' },
+}).frame('/', (c) => {
+  return c.res({
+    image: (
+      <VStack grow gap="4">
+        <Heading color="text400">
+          Current time: {new Date().toISOString()}
+        </Heading>
+      </VStack>
+    ),
+  })
+})

--- a/playground/src/index.tsx
+++ b/playground/src/index.tsx
@@ -4,6 +4,7 @@ import { devtools } from 'frog/dev'
 import * as hubs from 'frog/hubs'
 import { Box, Heading, vars } from './ui.js'
 
+import { app as clock } from './clock.js'
 import { app as fontsApp } from './fonts.js'
 import { app as middlewareApp } from './middleware.js'
 import { app as neynarApp } from './neynar.js'
@@ -177,6 +178,7 @@ export const app = new Frog({
       ],
     })
   })
+  .route('/clock', clock)
   .route('/ui', uiSystemApp)
   .route('/fonts', fontsApp)
   .route('/middleware', middlewareApp)

--- a/site/pages/reference/frog-frame-response.mdx
+++ b/site/pages/reference/frog-frame-response.mdx
@@ -103,7 +103,7 @@ app.frame('/frame/foo', (c) => {
   const { buttonIndex } = c
   return c.res({
     headers: { // [!code focus]
-      'Cache-Control': 'max-age=0', // [!code focus]
+      'cache-control': 'max-age=0', // [!code focus]
     }, // [!code focus]
     image: (
       <div style={{ color: 'white', display: 'flex', fontSize: 60 }}>

--- a/site/pages/reference/frog.mdx
+++ b/site/pages/reference/frog.mdx
@@ -67,7 +67,7 @@ import { Frog } from 'frog'
 
 const app = new Frog({
   headers: { // [!code focus]
-    'Cache-Control': 'max-age=0', // [!code focus]
+    'cache-control': 'max-age=0', // [!code focus]
   } // [!code focus]
 })
 ```

--- a/src/frog-base.tsx
+++ b/src/frog-base.tsx
@@ -322,7 +322,7 @@ export class FrogBase<
           )
           if (!frogImage)
             throw new Error(
-              'Unexpected error: frog:image meta tag is not present in the frame url.',
+              'Unexpected error: frog:image meta tag is not present in the frame.',
             )
           // Redirect to this route but now with search params and return the response
           return c.redirect(frogImage.content)

--- a/src/frog-base.tsx
+++ b/src/frog-base.tsx
@@ -312,8 +312,8 @@ export class FrogBase<
         const url = getRequestUrl(c.req)
 
         const query = c.req.query()
-        if (Object.keys(query).length === 0) {
-          // If the query is empty, it is an initial request to a frame.
+        if (!query.image) {
+          // If the query is doesn't have an image, it is an initial request to a frame.
           // Therefore we need to get the link to fetch the original image and jump once again in this method to resolve the options,
           // but now with query params set.
           const metadata = await getFrameMetadata(url.href.slice(0, -6)) // Stripping `/image` (6 characters) from the end of the url.

--- a/src/frog-base.tsx
+++ b/src/frog-base.tsx
@@ -310,19 +310,6 @@ export class FrogBase<
     for (const imagePath of imagePaths) {
       this.hono.get(imagePath, async (c) => {
         const url = getRequestUrl(c.req)
-        const defaultImageOptions = await (async () => {
-          if (typeof this.imageOptions === 'function')
-            return await this.imageOptions()
-          return this.imageOptions
-        })()
-
-        const fonts = await (async () => {
-          if (this.ui?.vars?.fonts)
-            return Object.values(this.ui?.vars.fonts).flat()
-          if (typeof options?.fonts === 'function') return await options.fonts()
-          if (options?.fonts) return options.fonts
-          return defaultImageOptions?.fonts
-        })()
 
         const query = c.req.query()
         if (Object.keys(query).length === 0) {
@@ -340,6 +327,20 @@ export class FrogBase<
           // Redirect to this route but now with search params and return the response
           return c.redirect(frogImage.content)
         }
+
+        const defaultImageOptions = await (async () => {
+          if (typeof this.imageOptions === 'function')
+            return await this.imageOptions()
+          return this.imageOptions
+        })()
+
+        const fonts = await (async () => {
+          if (this.ui?.vars?.fonts)
+            return Object.values(this.ui?.vars.fonts).flat()
+          if (typeof options?.fonts === 'function') return await options.fonts()
+          if (options?.fonts) return options.fonts
+          return defaultImageOptions?.fonts
+        })()
 
         const {
           headers = this.headers,

--- a/src/frog-base.tsx
+++ b/src/frog-base.tsx
@@ -481,7 +481,6 @@ export class FrogBase<
               ),
             ),
           )
-
           const imageParams = toSearchParams({
             image: compressedImage,
             imageOptions: imageOptions

--- a/src/utils/getFrameMetadata.ts
+++ b/src/utils/getFrameMetadata.ts
@@ -19,6 +19,7 @@ type FrameMetaTagPropertyName =
 
 type FrogMetaTagPropertyName =
   | 'frog:context'
+  | 'frog:image'
   | 'frog:prev_context'
   | 'frog:version'
 


### PR DESCRIPTION
This PR is a result of a research on why the frames with `Cache-Control: max-age=0` are not refreshing.

First of all, the passed `Cache-Control` header **must be lowercased**. What happens is that `@vercel/og` is setting a *lowercased* [`cache-control` header key to `"public, immutable, no-transform, max-age=31536000"` ](https://github.com/dalechyn/frog-next-cache-test/blob/172763e95409082d789ecfee9ee9ac7bf817cef3/patches/%40vercel__og%400.6.2.patch), yet `hono-og` sets [`Cache-Control` (different case) to `"public, immutable, no-transform, max-age=31536000"` (same value as prev one)](https://github.com/dalechyn/frog-next-cache-test/blob/172763e95409082d789ecfee9ee9ac7bf817cef3/patches/hono-og%400.0.26.patch#L27).
Even if a user doesn't pass any `headers` in `imageOptions`, what ends up being under the hood there – is an object with both `cache-control` and `Cache-Control` headers set, and it looks like that the *lowercased* header takes a precedence over the *uppercased* one, since it started working correctly without patches when I've passed a lowercased header key.

Secondly, WC caches the initial image url and expects you to update it under the same URL. However, since the `image`, `imageOptions` and `headers` are serialized and passed inside search params, the initial `/image?=image...` link will always change if the image is changing.
So I've decided to add an internal `frog:image` (maybe change to `frog:initial_image`?) meta tag that stores the full link to the image with search params. This allows to serve the image for initial frame request under `/image` route without any search params whatsoever by fetching the original frame, retrieving `frog:image` and redirecting user to it.
It's not ideal – as it adds up an additional request for image retrieval (breaks idempotency), uneffectively re-rendering the frame twice: first time when the frame is accessed (i.e. `/`), and then to retrieve `frog:image` from the image route (i.e. `/image`), which could cause some slow frames to time out. I cannot figure another way to persist the image state yet.
However it doesn't seem as a huge problem as "usually" initial frames are resolved fast, as there is no `frameData` to perform expensive operations with.

-------

As I write this long description, I think that what can be done though – is explicitly asking a user to opt out to a "refreshing" frame or not, warning him that the initial frame render will force it to render twice and setting `cache-control:max-age=0` in headers and performing this trick only if the flag is set.