### PR TITLE
refer to frames spec for post_url field as context in Button.Transaction

### DIFF
--- a/site/pages/intents/button-transaction.mdx
+++ b/site/pages/intents/button-transaction.mdx
@@ -37,7 +37,7 @@ app.frame('/', (c) => {
 
 - **Type:** `string`
 
-Path of the next frame to perform a `POST` request.
+Path of the next frame to perform a `POST` request. Farcaster Frames [Specifaction](https://docs.farcaster.xyz/reference/frames/spec#tx) refers to it as individual post_url property of that specific button.
 
 ### target
 

--- a/site/pages/intents/button-transaction.mdx
+++ b/site/pages/intents/button-transaction.mdx
@@ -37,7 +37,7 @@ app.frame('/', (c) => {
 
 - **Type:** `string`
 
-Path of the next frame to perform a `POST` request. Farcaster Frames [Specifaction](https://docs.farcaster.xyz/reference/frames/spec#tx) refers to it as individual post_url property of that specific button.
+Path of the next frame to perform a `POST` request. Farcaster Frames [Specifaction](https://docs.farcaster.xyz/reference/frames/spec#tx) refers to it as a `post_url` property of that button.
 
 ### target
 


### PR DESCRIPTION
Add context for developers coming to frog from other frames building frameworks or who have deep knowledge of the Frames Specification and are looking to match the field names in frog, while not changing frog.fm and just providing the context in the documentation.

![Screenshot 2024-04-04 at 01 32 09](https://github.com/wevm/frog/assets/40248495/f3de2f05-8076-4917-859e-4543625a53aa)
