### PR TITLE
clearly state address property frog-transaction-context.mdx

### DIFF
--- a/site/pages/reference/frog-transaction-context.mdx
+++ b/site/pages/reference/frog-transaction-context.mdx
@@ -21,7 +21,9 @@ A transaction handler can also be asynchronous (ie. `async (c) => { ... }{:js}`)
 
 - **Type**: `string | undefined`
 
-The address of a wallet that sends a transaction.
+The address of the wallet connected by the user after pressing the button to do the transaction.
+
+This is the wallet address the user executes the transaction with.
 
 ```tsx twoslash
 // @noErrors


### PR DESCRIPTION
Clearly state what address in transaction context means