### PR TITLE
fix: Adding Address type to FrameData

### DIFF
--- a/.changeset/rude-pugs-guess.md
+++ b/.changeset/rude-pugs-guess.md
@@ -1,0 +1,5 @@
+---
+"frog": patch
+---
+
+Adding Address type to FrameData

--- a/site/pages/reference/frog-transaction-context.mdx
+++ b/site/pages/reference/frog-transaction-context.mdx
@@ -19,7 +19,7 @@ A transaction handler can also be asynchronous (ie. `async (c) => { ... }{:js}`)
 
 ## address
 
-- **Type**: `string | undefined`
+- **Type**: `Address | string | undefined`
 
 The address of the wallet connected by the user after pressing the button to do the transaction.
 

--- a/src/types/frame.ts
+++ b/src/types/frame.ts
@@ -1,5 +1,5 @@
 import { type ImageResponseOptions } from 'hono-og'
-import type { Hash } from 'viem'
+import type { Hash, Address } from 'viem'
 import type { TypedResponse } from './response.js'
 
 export type Font = {
@@ -132,7 +132,7 @@ export type FrameResponseFn = (
 ) => TypedResponse<FrameResponse>
 
 export type FrameData = {
-  address?: string | undefined
+  address?: Address | string | undefined
   buttonIndex?: 1 | 2 | 3 | 4 | undefined
   castId: { fid: number; hash: string }
   fid: number


### PR DESCRIPTION
## Description

Adding the `Address` type to `FrameData.address`, which fixes a type error when trying to use `address` in the `args` array.

### Screenshot of type error

<img width="1288" alt="Screenshot 2024-04-10 at 7 40 21 PM" src="https://github.com/wevm/frog/assets/716376/df2b9383-8ee1-4762-b94d-5addf85e4140">
