### PR TITLE
docs: Add tips for usage with the next page-router

### DIFF
--- a/site/pages/platforms/next.mdx
+++ b/site/pages/platforms/next.mdx
@@ -128,10 +128,6 @@ If your app is relying on the page router, the exports will change slightly:
 
 ```tsx twoslash [pages/api/[[...route]].ts]
 // @noErrors
-
-// export const GET = handle(app);
-// export const POST = handle(app);
-
 export default handle(app); // [!code focus]
 ```
 

--- a/site/pages/platforms/next.mdx
+++ b/site/pages/platforms/next.mdx
@@ -120,6 +120,23 @@ export const GET = handle(app) // [!code focus]
 export const POST = handle(app) // [!code focus]
 ```
 
+:::tip
+
+**Next.js Pages Router**
+
+If your app is relying on the page router, the exports will change slightly:
+
+```tsx twoslash [pages/api/[[...route]].ts]
+// @noErrors
+
+// export const GET = handle(app);
+// export const POST = handle(app);
+
+export default handle(app); // [!code focus]
+```
+
+:::
+
 ### Setup Devtools
 
 Add Frog [Devtools](/concepts/devtools) after all frames are defined. This way the devtools can automatically discover all your frames.


### PR DESCRIPTION
The documented examples assume `frog` is being used with the Next.js app-router. It'd be helpful to add a small note/tip on the required changes to make page-router work.

This PR adds a small tip in the docs about the page-router, following [this example](https://hono.dev/getting-started/vercel) in Hono's docs.