### PR TITLE
fix: appearing port in reverse-proxied frame servers

### DIFF
--- a/.changeset/hungry-rivers-peel.md
+++ b/.changeset/hungry-rivers-peel.md
@@ -1,0 +1,5 @@
+---
+"frog": patch
+---
+
+Fixed an issue where port is appended to a reverse-proxied server. Now when `x-forwarded-host` is found, port is deleted.

--- a/src/utils/getRequestUrl.ts
+++ b/src/utils/getRequestUrl.ts
@@ -2,7 +2,9 @@ import type { Context } from 'hono'
 
 export function getRequestUrl(req: Context['req']) {
   const url = new URL(req.url)
-  url.host = req.header('x-forwarded-host') ?? url.host
+  const forwardedHost = req.header('x-forwarded-host')
+  url.host = forwardedHost ?? url.host
   url.protocol = req.header('x-forwarded-proto') ?? url.protocol
+  if (forwardedHost) url.port = ''
   return url
 }


### PR DESCRIPTION
This issue touched multiple people running frog in GCP, Wrangler and with NextJS+ngrok.

Example:

NextJS template, serves frog at `http://localhost:3000/api`.
Then you run `ngrok http 3000` to target port `3000` and reverse proxy it through https tunnel.
While `url.host` is replaced with `x-forwarded-host`, `url.port` still has value of `3000`.
