### PR TITLE
fix: image and postUrl urls

### DIFF
--- a/.changeset/sharp-timers-glow.md
+++ b/.changeset/sharp-timers-glow.md
@@ -1,0 +1,5 @@
+---
+"frog": patch
+---
+
+Fixed the issue with Frog instances that set `origin` property not being respected in `image` and `postUrl` urls.

--- a/src/frog-base.tsx
+++ b/src/frog-base.tsx
@@ -536,7 +536,7 @@ export class FrogBase<
               : undefined,
             headers,
           })
-          return `${parsePath(context.url)}/image?${imageParams}`
+          return `${baseUrl}/image?${imageParams}`
         }
         if (image.startsWith('http') || image.startsWith('data')) return image
         return `${assetsUrl + parsePath(image)}`
@@ -549,7 +549,7 @@ export class FrogBase<
       })()
 
       const postUrl = (() => {
-        if (!action) return context.url
+        if (!action) return baseUrl
         if (action.startsWith('http')) return action
         return baseUrl + parsePath(action)
       })()


### PR DESCRIPTION
Regression test:

1. Create frog app with nextjs template;
2. Start ngrok targeting nexts served port;
3. Go to the api route and the meta tags would refer localhost instead of ngrok.