### PR TITLE
fix: don't delete port if forwarded host is localhost

### DIFF
--- a/.changeset/tasty-spoons-cheat.md
+++ b/.changeset/tasty-spoons-cheat.md
@@ -1,0 +1,5 @@
+---
+"frog": patch
+---
+
+Fixed an issue with local devtools with nextjs template that sets `x-forwarded-host` header to `localhost` which previously deleted the port and ended up creating incorrect link.

--- a/src/utils/getRequestUrl.ts
+++ b/src/utils/getRequestUrl.ts
@@ -5,6 +5,6 @@ export function getRequestUrl(req: Context['req']) {
   const forwardedHost = req.header('x-forwarded-host')
   url.host = forwardedHost ?? url.host
   url.protocol = req.header('x-forwarded-proto') ?? url.protocol
-  if (forwardedHost) url.port = ''
+  if (!forwardedHost?.startsWith('localhost')) url.port = ''
   return url
 }


### PR DESCRIPTION
Fixes #253.