### PR TITLE
fix: render initial frame image from image handler

### DIFF
--- a/.changeset/funny-cups-kick.md
+++ b/.changeset/funny-cups-kick.md
@@ -1,0 +1,5 @@
+---
+"frog": patch
+---
+
+Dropped `frog:image` meta tag in favor of having the image handler to render the initial frame image itself. Fixed wrangler/edge deployment issues that were caused by requesting for `frog:image` tag at the frame handler from image handler where it is limited by wrangler/edge api.

--- a/playground/src/index.tsx
+++ b/playground/src/index.tsx
@@ -89,6 +89,22 @@ export const app = new Frog({
       ],
     })
   })
+  .frame('/square', (c) => {
+    return c.res({
+      image: <Box grow backgroundColor="red" />,
+      intents: [
+        <Button.Redirect location="http://github.com/honojs/vite-plugins/tree/main/packages/dev-server">
+          Redirect
+        </Button.Redirect>,
+        <Button.Link href="https://www.example.com">Link</Button.Link>,
+        <Button.Mint target="eip155:7777777:0x060f3edd18c47f59bd23d063bbeb9aa4a8fec6df">
+          Mint
+        </Button.Mint>,
+        <Button.Reset>Reset</Button.Reset>,
+      ],
+      imageAspectRatio: '1:1',
+    })
+  })
   .frame('/no-intents', (c) => {
     return c.res({
       image: <Box grow backgroundColor="red" />,

--- a/src/frog-base.tsx
+++ b/src/frog-base.tsx
@@ -420,7 +420,7 @@ export class FrogBase<
                     width: '100%',
                   }}
                 >
-                  {await response.data.image}
+                  {await image}
                 </div>,
                 {
                   assetsUrl,

--- a/src/next/getFrameMetadata.test.ts
+++ b/src/next/getFrameMetadata.test.ts
@@ -20,7 +20,6 @@ test('default', async () => {
       "fc:frame:image": "https://frame.frog.fm/api/image",
       "fc:frame:image:aspect_ratio": "1.91:1",
       "fc:frame:post_url": "https://frame.frog.fm/api?initialPath=%252Fapi&amp;previousButtonValues=%2523A_%252C_l%252C_l",
-      "frog:image": "https://frame.frog.fm/og.png",
       "og:image": "https://frame.frog.fm/api/image",
       "og:title": "Frog Frame",
     }

--- a/src/utils/getFrameMetadata.test.ts
+++ b/src/utils/getFrameMetadata.test.ts
@@ -66,11 +66,7 @@ test('default', async () => {
       {
         "content": "https://github.com/wevm/frog",
         "property": "fc:frame:button:3:target",
-      },
-      {
-        "content": "https://frame.frog.fm/og.png",
-        "property": "frog:image",
-      },
+      }
     ]
   `)
 })

--- a/src/utils/getFrameMetadata.ts
+++ b/src/utils/getFrameMetadata.ts
@@ -19,7 +19,6 @@ type FrameMetaTagPropertyName =
 
 type FrogMetaTagPropertyName =
   | 'frog:context'
-  | 'frog:image'
   | 'frog:prev_context'
   | 'frog:version'
 


### PR DESCRIPTION
Previously, `frog:image` meta tag was used as a workaround that held the
full image URL which has an `image` query parameter that contains a
compressed serialized image itself.
However, initial frame image doesn't have `c.frameData`-based constraints
as it is not present on the initial render.

This change moves the initial image render responsibility to the `/image`
handler itself, removing the request from an `/image` route one level up
to get the full URL from `frog:image`, and removes this meta tag as
well.

Double request or a request within self has created issues with wrangler
deployments (that I tried to fix in https://github.com/wevm/frog/pull/268 by opting out from `frog:image`
tag and falling back to long initial frame image URL), and created
issues within Vercel Edge deployments that treat such a request as an
"Infinite" one.

Supersedes https://github.com/wevm/frog/pull/268.