### PR TITLE
fix: delete `frog:image` meta tag 

### DIFF
--- a/.changeset/quick-rivers-own.md
+++ b/.changeset/quick-rivers-own.md
@@ -1,0 +1,5 @@
+---
+"frog": patch
+---
+
+Reverted changes from #222 that have caused issues in wrangler and edge environments. Intentionally introduced regression with "refreshing frame images" as #222 focused on bringing those work.

--- a/src/frog-base.tsx
+++ b/src/frog-base.tsx
@@ -352,25 +352,6 @@ export class FrogBase<
     const imagePaths = getImagePaths(parseHonoPath(path))
     for (const imagePath of imagePaths) {
       this.hono.get(imagePath, async (c) => {
-        const url = getRequestUrl(c.req)
-
-        const query = c.req.query()
-        if (!query.image) {
-          // If the query is doesn't have an image, it is an initial request to a frame.
-          // Therefore we need to get the link to fetch the original image and jump once again in this method to resolve the options,
-          // but now with query params set.
-          const metadata = await getFrameMetadata(url.href.slice(0, -6)) // Stripping `/image` (6 characters) from the end of the url.
-          const frogImage = metadata.find(
-            ({ property }) => property === 'frog:image',
-          )
-          if (!frogImage)
-            throw new Error(
-              'Unexpected error: frog:image meta tag is not present in the frame.',
-            )
-          // Redirect to this route but now with search params and return the response
-          return c.redirect(frogImage.content)
-        }
-
         const defaultImageOptions = await (async () => {
           if (typeof this.imageOptions === 'function')
             return await this.imageOptions()
@@ -389,7 +370,7 @@ export class FrogBase<
           headers = this.headers,
           image,
           imageOptions = defaultImageOptions,
-        } = fromQuery<any>(query)
+        } = fromQuery<any>(c.req.query())
         const image_ = JSON.parse(lz.decompressFromEncodedURIComponent(image))
         return new ImageResponse(image_, {
           width: 1200,
@@ -672,22 +653,8 @@ export class FrogBase<
                 property="fc:frame:image:aspect_ratio"
                 content={imageAspectRatio}
               />
-              <meta
-                property="fc:frame:image"
-                content={
-                  context.status === 'initial'
-                    ? `${context.url}/image`
-                    : imageUrl
-                }
-              />
-              <meta
-                property="og:image"
-                content={
-                  ogImageUrl ?? context.status === 'initial'
-                    ? `${context.url}/image`
-                    : imageUrl
-                }
-              />
+              <meta property="fc:frame:image" content={imageUrl} />
+              <meta property="og:image" content={ogImageUrl ?? imageUrl} />
               <meta property="og:title" content={title} />
               <meta
                 property="fc:frame:post_url"
@@ -721,7 +688,6 @@ export class FrogBase<
                   })}
                 />
               )}
-              <meta property="frog:image" content={imageUrl} />
             </head>
             <body />
           </html>


### PR DESCRIPTION
Reverted changes from https://github.com/wevm/frog/pull/222 that have ultimately caused
issues in wrangler and edge environments.

Related: #271