### PR TITLE
feat: add arbitrum network

### DIFF
--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -21,8 +21,9 @@ export type ChainNamespace = 'eip155'
  * - 8453: Base
  * - 84532: Base Sepolia
  * - 7777777: Zora
+ * - 42161: Arbitrum
  */
-export type ChainIdEip155 = 1 | 10 | 8453 | 84532 | 7777777
+export type ChainIdEip155 = 1 | 10 | 8453 | 84532 | 7777777 | 42161
 
 export type TransactionParameters = {
   /** A CAIP-2 Chain ID to identify the transaction network. */

--- a/ui/src/lib/wagmi.ts
+++ b/ui/src/lib/wagmi.ts
@@ -1,10 +1,10 @@
 import { QueryClient } from '@tanstack/react-query'
 import { http, createConfig, createStorage } from 'wagmi'
-import { base, baseSepolia, mainnet, optimism, zora } from 'wagmi/chains'
+import { arbitrum, base, baseSepolia, mainnet, optimism, zora } from 'wagmi/chains'
 import { coinbaseWallet, walletConnect } from 'wagmi/connectors'
 
 export const config = createConfig({
-  chains: [mainnet, base, baseSepolia, optimism, zora],
+  chains: [mainnet, base, baseSepolia, optimism, zora, arbitrum],
   connectors: [
     coinbaseWallet({ appName: 'Frog Devtools', headlessMode: true }),
     walletConnect({
@@ -19,6 +19,7 @@ export const config = createConfig({
     [baseSepolia.id]: http(),
     [optimism.id]: http(),
     [zora.id]: http(),
+		[arbitrum.id]: http(),
   },
 })
 


### PR DESCRIPTION
## Description
I have added code in this PR regarding support for the Arbitrum chain.
I referred to this [PR](https://github.com/wevm/frog/pull/208).

## Motivation
I am currently working on a Farcaster frame for Gitcoin grant donations using frog. This round they have adopted Arbitrum, which is outside the frog supported chain.
Therefore, I am pushing to support Arbitrum.
Also, Arbitrum is a high TVL for DeFi, so I have no doubt that there will be frames in the future that will allow native interaction with DeFi.

I may be missing some implementation, then plz add required impl.