### PR TITLE
feat: add `gas` parameter to transaction response

### DIFF
--- a/.changeset/fair-lions-vanish.md
+++ b/.changeset/fair-lions-vanish.md
@@ -1,0 +1,5 @@
+---
+"frog": patch
+---
+
+Added `gas` parameter to transaction response to specify the gas limit. [See more](https://warpcast.com/horsefacts.eth/0xd6390bb3).

--- a/site/pages/reference/frog-transaction-response.mdx
+++ b/site/pages/reference/frog-transaction-response.mdx
@@ -83,7 +83,7 @@ app.transaction('/send-ether', (c) => {
 
 ### gas (optional)
 
-- **Type:** `Bigint`
+- **Type:** `BigInt`
 
 Gas limit of the transaction to send.
 

--- a/site/pages/reference/frog-transaction-response.mdx
+++ b/site/pages/reference/frog-transaction-response.mdx
@@ -81,6 +81,28 @@ app.transaction('/send-ether', (c) => {
 })
 ```
 
+### gas (optional)
+
+- **Type:** `Bigint`
+
+Gas limit of the transaction to send.
+
+```tsx twoslash
+// @noErrors
+import { Frog, parseEther } from 'frog'
+ 
+export const app = new Frog()
+
+app.transaction('/send-ether', (c) => {
+  return c.send({ 
+    chainId: 'eip155:10',
+    gas: 100_000n, // [!code focus]
+    to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+    value: parseEther('1'),
+  }) 
+})
+```
+
 ### to
 
 - **Type:** `Address`
@@ -104,7 +126,7 @@ app.transaction('/send-ether', (c) => {
 
 ### value
 
-- **Type:** `Address`
+- **Type:** `Bigint`
 
 Value (in wei) to send with the transaction.
 
@@ -256,6 +278,28 @@ app.transaction('/mint', (c) => {
 })
 ```
 
+### gas (optional)
+
+- **Type:** `Bigint`
+
+Gas limit of the transaction to send.
+
+```tsx twoslash
+// @noErrors
+import { Frog, parseEther } from 'frog'
+ 
+export const app = new Frog()
+
+app.transaction('/send-ether', (c) => {
+  return c.send({ 
+    chainId: 'eip155:10',
+    gas: 100_000n, // [!code focus]
+    to: '0xd2135CfB216b74109775236E36d4b433F1DF507B',
+    value: parseEther('1'),
+  }) 
+})
+```
+
 ### args
 
 - **Type:** `unknown`
@@ -328,7 +372,7 @@ app.transaction('/mint', (c) => {
 
 ### value (optional)
 
-- **Type:** `Address`
+- **Type:** `Bigint`
 
 Value to send with the transaction.
 

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -55,7 +55,7 @@ export type EthSendTransactionParameters<quantity = string> = {
   /** Transaction calldata. */
   data?: Hex | undefined
   /** Gas limit for the transaction. */
-  gas?: quantity
+  gas?: quantity | undefined
   /** Transaction target address. */
   to: Hex
   /** Value to send with transaction (in wei). */

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -54,6 +54,8 @@ export type EthSendTransactionParameters<quantity = string> = {
   attribution?: boolean | undefined
   /** Transaction calldata. */
   data?: Hex | undefined
+  /** Gas limit for the transaction. */
+  gas?: quantity
   /** Transaction target address. */
   to: Hex
   /** Value to send with transaction (in wei). */

--- a/src/utils/getTransactionContext.ts
+++ b/src/utils/getTransactionContext.ts
@@ -107,7 +107,7 @@ export function getTransactionContext<
       req,
       res(parameters) {
         const { attribution, chainId, method, params } = parameters
-        const { abi, data, to, value } = params
+        const { abi, data, gas, to, value } = params
         const response: TransactionResponse = {
           attribution,
           chainId,
@@ -118,6 +118,7 @@ export function getTransactionContext<
             to,
           },
         }
+        if (gas) response.params.gas = gas.toString()
         if (value) response.params.value = value.toString()
         return { data: response, format: 'transaction', status: 'success' }
       },


### PR DESCRIPTION
[See more](https://warpcast.com/horsefacts.eth/0xd6390bb3).

this is not covered in docs but is supported.