### PR TITLE
feat: add frame validate using neynar for neynar hubs

### DIFF
--- a/.changeset/shiny-parents-smile.md
+++ b/.changeset/shiny-parents-smile.md
@@ -1,0 +1,5 @@
+---
+"frog": patch
+---
+
+Added `verifyFrame` option to hub definition.

--- a/src/hubs/neynar.ts
+++ b/src/hubs/neynar.ts
@@ -25,7 +25,7 @@ export const neynar = createHub((parameters: NeynarHubParameters) => {
         method: 'POST',
         headers: {
           accept: 'application json',
-          api_key: 'NEYNAR_FROG_FM',
+          api_key: apiKey,
           'content-type': 'application/json',
         },
         body: JSON.stringify({

--- a/src/hubs/neynar.ts
+++ b/src/hubs/neynar.ts
@@ -8,8 +8,6 @@ export type NeynarHubParameters = {
 export const neynar = createHub((parameters: NeynarHubParameters) => {
   const { apiKey } = parameters
 
-  console.log('NEYNAR REQ')
-
   return {
     apiUrl: 'https://hub-api.neynar.com',
     fetchOptions: {

--- a/src/hubs/neynar.ts
+++ b/src/hubs/neynar.ts
@@ -1,3 +1,9 @@
+import { hexToBytes } from 'viem'
+import { Message } from '../protobufs/generated/message_pb.js'
+import {
+  type VerifyFrameParameters,
+  messageToFrameData,
+} from '../utils/verifyFrame.js'
 import { createHub } from './utils.js'
 
 export type NeynarHubParameters = {
@@ -6,6 +12,39 @@ export type NeynarHubParameters = {
 
 export const neynar = createHub((parameters: NeynarHubParameters) => {
   const { apiKey } = parameters
+
+  const verifyFrame = async ({
+    frameUrl,
+    trustedData,
+    url,
+  }: VerifyFrameParameters) => {
+    const bytes = hexToBytes(`0x${trustedData.messageBytes}`)
+    const response = await fetch(
+      'https://api.neynar.com/v2/farcaster/frame/validate',
+      {
+        method: 'POST',
+        headers: {
+          accept: 'application json',
+          api_key: 'NEYNAR_FROG_FM',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          message_bytes_in_hex: `0x${trustedData.messageBytes}`,
+        }),
+      },
+    ).then(async (res) => res.json())
+
+    if (!response.valid)
+      throw new Error(`message is invalid. ${response.message}`)
+
+    if (new URL(url).origin !== new URL(frameUrl).origin)
+      throw new Error(`Invalid frame url: ${frameUrl}. Expected: ${url}.`)
+
+    const message = Message.fromBinary(bytes)
+    const frameData = messageToFrameData(message)
+    return { frameData }
+  }
+
   return {
     apiUrl: 'https://hub-api.neynar.com',
     fetchOptions: {
@@ -13,5 +52,6 @@ export const neynar = createHub((parameters: NeynarHubParameters) => {
         api_key: apiKey,
       },
     },
+    verifyFrame,
   }
 })

--- a/src/hubs/neynar.ts
+++ b/src/hubs/neynar.ts
@@ -1,9 +1,4 @@
-import { hexToBytes } from 'viem'
-import { Message } from '../protobufs/generated/message_pb.js'
-import {
-  type VerifyFrameParameters,
-  messageToFrameData,
-} from '../utils/verifyFrame.js'
+import type { TrustedData } from '../types/frame.js'
 import { createHub } from './utils.js'
 
 export type NeynarHubParameters = {
@@ -13,15 +8,17 @@ export type NeynarHubParameters = {
 export const neynar = createHub((parameters: NeynarHubParameters) => {
   const { apiKey } = parameters
 
-  const verifyFrame = async ({
-    frameUrl,
-    trustedData,
-    url,
-  }: VerifyFrameParameters) => {
-    const bytes = hexToBytes(`0x${trustedData.messageBytes}`)
-    const response = await fetch(
-      'https://api.neynar.com/v2/farcaster/frame/validate',
-      {
+  console.log('NEYNAR REQ')
+
+  return {
+    apiUrl: 'https://hub-api.neynar.com',
+    fetchOptions: {
+      headers: {
+        api_key: apiKey,
+      },
+    },
+    verifyFrame: async ({ trustedData }: { trustedData: TrustedData }) => {
+      return await fetch('https://api.neynar.com/v2/farcaster/frame/validate', {
         method: 'POST',
         headers: {
           accept: 'application json',
@@ -31,27 +28,7 @@ export const neynar = createHub((parameters: NeynarHubParameters) => {
         body: JSON.stringify({
           message_bytes_in_hex: `0x${trustedData.messageBytes}`,
         }),
-      },
-    ).then(async (res) => res.json())
-
-    if (!response.valid)
-      throw new Error(`message is invalid. ${response.message}`)
-
-    if (new URL(url).origin !== new URL(frameUrl).origin)
-      throw new Error(`Invalid frame url: ${frameUrl}. Expected: ${url}.`)
-
-    const message = Message.fromBinary(bytes)
-    const frameData = messageToFrameData(message)
-    return { frameData }
-  }
-
-  return {
-    apiUrl: 'https://hub-api.neynar.com',
-    fetchOptions: {
-      headers: {
-        api_key: apiKey,
-      },
+      }).then(async (res) => res.json())
     },
-    verifyFrame,
   }
 })

--- a/src/types/hub.ts
+++ b/src/types/hub.ts
@@ -5,7 +5,7 @@ export type Hub = {
   apiUrl: string
   /** Options to pass to `fetch`. */
   fetchOptions?: RequestInit
-  /** Verify a frame. */
+  /** Verify frame override. */
   verifyFrame?: ({
     trustedData,
   }: {

--- a/src/types/hub.ts
+++ b/src/types/hub.ts
@@ -1,4 +1,4 @@
-import type { VerifyFrameParameters } from '../utils/verifyFrame.js'
+import type { TrustedData } from './frame.js'
 
 export type Hub = {
   /** Hub API URL. */
@@ -7,12 +7,8 @@ export type Hub = {
   fetchOptions?: RequestInit
   /** Verify a frame. */
   verifyFrame?: ({
-    frameUrl,
-    hub,
     trustedData,
-    body,
-    url,
-  }: VerifyFrameParameters & { body: Uint8Array }) => Promise<{
-    frameData: any
-  }>
+  }: {
+    trustedData: TrustedData
+  }) => Promise<void>
 }

--- a/src/types/hub.ts
+++ b/src/types/hub.ts
@@ -6,9 +6,5 @@ export type Hub = {
   /** Options to pass to `fetch`. */
   fetchOptions?: RequestInit
   /** Verify frame override. */
-  verifyFrame?: ({
-    trustedData,
-  }: {
-    trustedData: TrustedData
-  }) => Promise<void>
+  verifyFrame?: (parameters: { trustedData: TrustedData }) => Promise<void>
 }

--- a/src/types/hub.ts
+++ b/src/types/hub.ts
@@ -1,6 +1,18 @@
+import type { VerifyFrameParameters } from '../utils/verifyFrame.js'
+
 export type Hub = {
   /** Hub API URL. */
   apiUrl: string
   /** Options to pass to `fetch`. */
   fetchOptions?: RequestInit
+  /** Verify a frame. */
+  verifyFrame?: ({
+    frameUrl,
+    hub,
+    trustedData,
+    body,
+    url,
+  }: VerifyFrameParameters & { body: Uint8Array }) => Promise<{
+    frameData: any
+  }>
 }

--- a/src/utils/verifyFrame.test.ts
+++ b/src/utils/verifyFrame.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import { frog } from '../hubs/frog.js'
+import { neynar } from '../hubs/neynar.js'
 import { verifyFrame } from './verifyFrame.js'
 
 test('valid', async () => {
@@ -35,6 +36,53 @@ test('invalid url', async () => {
     verifyFrame({
       frameUrl: 'https://test-farc7.vercel.app/api',
       hub: frog(),
+      trustedData: { messageBytes },
+      url: 'https://test-farc6.vercel.app/foo',
+    }),
+  ).rejects.toMatchInlineSnapshot(
+    '[Error: Invalid frame url: https://test-farc7.vercel.app/api. Expected: https://test-farc6.vercel.app/foo.]',
+  )
+})
+
+test('valid neynar', async () => {
+  const messageBytes =
+    '0a4f080d10ff2f18c1a6802f20018201400a2168747470733a2f2f746573742d66617263362e76657263656c2e6170702f61706910011a1908ff2f1214000000000000000000000000000000000000000112141de03010b0ce4f39ba4b8ff29851d0d610dc5ddd180122404aab47af096150fe7193713722bcdd6ddcd6cd35c1e84cc42e7713624916a97568fa8232e2ffd70ce5eeafb0391c7bbcdf6c5ba15a9a02834102b016058e7d0128013220daa3f0a5335900f542a266e4b837309aeac52d736f4cf9b2eff0d4c4f4c7e58f'
+  await verifyFrame({
+    frameUrl: 'https://test-farc6.vercel.app/api/foo',
+    hub: neynar({
+      apiKey: 'NEYNAR_FROG_FM',
+    }),
+    trustedData: { messageBytes },
+    url: 'https://test-farc6.vercel.app/api',
+  })
+})
+
+test('invalid hash neynar', async () => {
+  const messageBytes =
+    '0a4d080d10ff2f18c1a6802f20018201400a2168747470733a2a2f746573742d66617263362e76657263656c2e6170702f61706910011a1908ff2f1214000000000000000000000000000000000000000112141de03010b0ce4f39ba4b8ff29851d0d610dc5ddd180122404aab47af096150fe7193713722bcdd6ddcd6cd35c1e84cc42e7713624916a97568fa8232e2ffd70ce5eeafb0391c7bbcdf6c5ba15a9a02834102b016058e7d0128013220daa3f0a5335900f542a266e4b837309aeac52d736f4cf9b2eff0d4c4f4c7e58f'
+  await expect(() =>
+    verifyFrame({
+      frameUrl: 'https://test-farc6.vercel.app/api',
+      hub: neynar({
+        apiKey: 'NEYNAR_FROG_FM',
+      }),
+      trustedData: { messageBytes },
+      url: 'https://test-farc6.vercel.app/api',
+    }),
+  ).rejects.toMatchInlineSnapshot(
+    '[Error: message is invalid. No data in message.]',
+  )
+})
+
+test('invalid url neynar', async () => {
+  const messageBytes =
+    '0a49080d1085940118f6a6a32e20018201390a1a86db69b3ffdf6ab8acb6872b69ccbe7eb6a67af7ab71e95aa69f10021a1908ef011214237025b322fd03a9ddc7ec6c078fb9c56d1a72111214e3d88aeb2d0af356024e0c693f31c11b42c76b721801224043cb2f3fcbfb5dafce110e934b9369267cf3d1aef06f51ce653dc01700fc7b778522eb7873fd60dda4611376200076caf26d40a736d3919ce14e78a684e4d30b280132203a66717c82d728beb3511b05975c6603275c7f6a0600370bf637b9ecd2bd231e'
+  await expect(() =>
+    verifyFrame({
+      frameUrl: 'https://test-farc7.vercel.app/api',
+      hub: neynar({
+        apiKey: 'NEYNAR_FROG_FM',
+      }),
       trustedData: { messageBytes },
       url: 'https://test-farc6.vercel.app/foo',
     }),

--- a/src/utils/verifyFrame.ts
+++ b/src/utils/verifyFrame.ts
@@ -21,22 +21,23 @@ export async function verifyFrame({
   url,
 }: VerifyFrameParameters): Promise<VerifyFrameReturnType> {
   const body = hexToBytes(`0x${trustedData.messageBytes}`)
-  if (hub.verifyFrame) {
-    return await hub.verifyFrame({ hub, trustedData, body, frameUrl, url })
-  }
 
-  const response = await fetch(`${hub.apiUrl}/v1/validateMessage`, {
-    ...hub.fetchOptions,
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/octet-stream',
-      ...hub.fetchOptions?.headers,
-    },
-    body,
-  }).then((res) => res.json())
+  const response = hub.verifyFrame
+    ? await hub.verifyFrame({ trustedData })
+    : await fetch(`${hub.apiUrl}/v1/validateMessage`, {
+        ...hub.fetchOptions,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          ...hub.fetchOptions?.headers,
+        },
+        body,
+      }).then((res) => res.json())
 
   if (!response.valid)
-    throw new Error(`message is invalid. ${response.details}`)
+    throw new Error(
+      `message is invalid. ${response.details || response.message}`,
+    )
 
   if (new URL(url).origin !== new URL(frameUrl).origin)
     throw new Error(`Invalid frame url: ${frameUrl}. Expected: ${url}.`)

--- a/src/utils/verifyFrame.ts
+++ b/src/utils/verifyFrame.ts
@@ -21,6 +21,10 @@ export async function verifyFrame({
   url,
 }: VerifyFrameParameters): Promise<VerifyFrameReturnType> {
   const body = hexToBytes(`0x${trustedData.messageBytes}`)
+  if (hub.verifyFrame) {
+    return await hub.verifyFrame({ hub, trustedData, body, frameUrl, url })
+  }
+
   const response = await fetch(`${hub.apiUrl}/v1/validateMessage`, {
     ...hub.fetchOptions,
     method: 'POST',
@@ -29,7 +33,7 @@ export async function verifyFrame({
       ...hub.fetchOptions?.headers,
     },
     body,
-  }).then((res) => res.json())
+  }).then(async (res) => res.json())
 
   if (!response.valid)
     throw new Error(`message is invalid. ${response.details}`)

--- a/src/utils/verifyFrame.ts
+++ b/src/utils/verifyFrame.ts
@@ -33,7 +33,7 @@ export async function verifyFrame({
       ...hub.fetchOptions?.headers,
     },
     body,
-  }).then(async (res) => res.json())
+  }).then((res) => res.json())
 
   if (!response.valid)
     throw new Error(`message is invalid. ${response.details}`)


### PR DESCRIPTION
Updated the neynar hub to validate the message using the neynar API instead of the default hub API. Using the neynar API has given significant performance boosts

![image](https://github.com/wevm/frog/assets/76690419/047b2593-6657-4534-baea-af5dd63a1423)
