### PR TITLE
Remove extra parenthesis from multi-step cast actions code

### DIFF
--- a/site/pages/concepts/multi-step-cast-actions.mdx
+++ b/site/pages/concepts/multi-step-cast-actions.mdx
@@ -141,7 +141,7 @@ app.castAction( // [!code focus]
     ) // [!code focus]
     return c.res({ type: 'frame', path: '/hello-world-frame' }) // [!code focus]
   }, // [!code focus]
-  { name: "Hello world!", icon: "smiley" }) // [!code focus]
+  { name: "Hello world!", icon: "smiley" } // [!code focus]
 ) // [!code focus]
 ```
 


### PR DESCRIPTION
Extra closing parenthesis in the multi-step cast actions code at the end of the cast action for `/hello-world`
