### PR TITLE
fix: frog_user cookie should also be checked; otherwise login won't work correctly for new sessions

### DIFF
--- a/.changeset/cyan-rabbits-join.md
+++ b/.changeset/cyan-rabbits-join.md
@@ -1,0 +1,5 @@
+---
+"frog": minor
+---
+
+Read frog_user cookie to prevent session logout.

--- a/.changeset/cyan-rabbits-join.md
+++ b/.changeset/cyan-rabbits-join.md
@@ -1,5 +1,5 @@
 ---
-"frog": minor
+"frog": patch
 ---
 
-Read frog_user cookie to prevent session logout.
+Fixed an issue with session logouts by reading `frog_user` cookie.

--- a/src/dev/devtools.tsx
+++ b/src/dev/devtools.tsx
@@ -168,7 +168,7 @@ export function routes(
       }
 
       let user: User | undefined = undefined
-      const cookie = getCookie(c, 'user')
+      const cookie = getCookie(c, 'frog_user') ?? getCookie(c, 'user')
       if (cookie)
         try {
           const parsed = JSON.parse(cookie)


### PR DESCRIPTION
If both are not checked then new sessions will have broken login handling.
(user is logged out after each page reload and must pay 10 warps again to sign back in)