### PR TITLE
fix: check for `prop` in `intent`

### DIFF
--- a/src/utils/getButtonValues.ts
+++ b/src/utils/getButtonValues.ts
@@ -8,7 +8,7 @@ export function getButtonValues(
 
   const buttonValues: FrameButtonValue[] = []
   for (const intent of intents) {
-    if (!intent) continue
+    if (!intent || !('props' in intent)) continue
     const { property } = intent.props
     if (!(property as string).match(/^fc:frame:button:(1|2|3|4)$/)) continue
     buttonValues.push(intent.props['data-value'])


### PR DESCRIPTION
This is quite a mysterious bug since it cannot be reproduced locally, and is only reproduced on Vercel/Next.js Platforms. I assume that some sort of build caching is being made and previous fixes didn't come through, thus trying now with this one.