### PR TITLE
fix: spelling error in docs

### DIFF
--- a/site/pages/platforms/bun.mdx
+++ b/site/pages/platforms/bun.mdx
@@ -77,7 +77,7 @@ app.frame('/', (c) => {
 ```
 
 :::tip
-Feel free to use the `neynar` hub aling with our Neynar API Key: `"NEYNAR_FROG_FM"`.
+Feel free to use the `neynar` hub along with our Neynar API Key: `"NEYNAR_FROG_FM"`.
 
 However, please note that this API Key is for development purposes only – it is prone to rate-limiting.
 It is recommended to use your own API Key in production. [See more](https://neynar.com/#get-started).

--- a/site/pages/platforms/cloudflare-workers.mdx
+++ b/site/pages/platforms/cloudflare-workers.mdx
@@ -72,7 +72,7 @@ app.frame('/', (c) => {
 ```
 
 :::tip
-Feel free to use the `neynar` hub aling with our Neynar API Key: `"NEYNAR_FROG_FM"`.
+Feel free to use the `neynar` hub along with our Neynar API Key: `"NEYNAR_FROG_FM"`.
 
 However, please note that this API Key is for development purposes only – it is prone to rate-limiting.
 It is recommended to use your own API Key in production. [See more](https://neynar.com/#get-started).

--- a/site/pages/platforms/next.mdx
+++ b/site/pages/platforms/next.mdx
@@ -73,7 +73,7 @@ app.frame('/', (c) => {
 ```
 
 :::tip
-Feel free to use the `neynar` hub aling with our Neynar API Key: `"NEYNAR_FROG_FM"`.
+Feel free to use the `neynar` hub along with our Neynar API Key: `"NEYNAR_FROG_FM"`.
 
 However, please note that this API Key is for development purposes only – it is prone to rate-limiting.
 It is recommended to use your own API Key in production. [See more](https://neynar.com/#get-started).

--- a/site/pages/platforms/node.mdx
+++ b/site/pages/platforms/node.mdx
@@ -62,7 +62,7 @@ app.frame('/', (c) => {
 ```
 
 :::tip
-Feel free to use the `neynar` hub aling with our Neynar API Key: `"NEYNAR_FROG_FM"`.
+Feel free to use the `neynar` hub along with our Neynar API Key: `"NEYNAR_FROG_FM"`.
 
 However, please note that this API Key is for development purposes only – it is prone to rate-limiting.
 It is recommended to use your own API Key in production. [See more](https://neynar.com/#get-started).

--- a/site/pages/platforms/vercel.mdx
+++ b/site/pages/platforms/vercel.mdx
@@ -76,7 +76,7 @@ app.frame('/', (c) => {
 ```
 
 :::tip
-Feel free to use the `neynar` hub aling with our Neynar API Key: `"NEYNAR_FROG_FM"`.
+Feel free to use the `neynar` hub along with our Neynar API Key: `"NEYNAR_FROG_FM"`.
 
 However, please note that this API Key is for development purposes only – it is prone to rate-limiting.
 It is recommended to use your own API Key in production. [See more](https://neynar.com/#get-started).


### PR DESCRIPTION
replaced `aling` with `along` wherever neynar api related block occured