### PR TITLE
fix: ts error showing up in docs

### DIFF
--- a/site/pages/reference/frog-composer-action-response.mdx
+++ b/site/pages/reference/frog-composer-action-response.mdx
@@ -24,6 +24,7 @@ app.composerAction('/', (c) => {
 Title of your action which will be shown in the footer of the Composer Form.
 
 ```tsx twoslash
+// @noErrors
 /** @jsxImportSource frog/jsx */
 // ---cut---
 import { Button, Frog } from 'frog'
@@ -32,7 +33,7 @@ export const app = new Frog({ title: 'Frog Frame' })
  
 app.composerAction('/', (c) => {
     return c.res({
-      title: 'My Composr Action', // [!code focus]
+      title: 'My Composer Action', // [!code focus]
       url: 'https://example.com'
     })
   },
@@ -47,6 +48,7 @@ app.composerAction('/', (c) => {
 Composer Form URL. Must be http:// or https:// protocol.
 
 ```tsx twoslash
+// @noErrors
 /** @jsxImportSource frog/jsx */
 // ---cut---
 import { Button, Frog } from 'frog'


### PR DESCRIPTION
<img width="1440" alt="composer_errors" src="https://github.com/user-attachments/assets/cb0436f8-ff52-44a1-97a7-6b71d9d715f3">

In the docs. These ts errors show up. [Reference](https://frog.fm/reference/frog-composer-action-response). From the point of the reader, it looks "odd". I assume it isn't intended to show up. 
This PR remove them