### PR TITLE
fix template bug, default composer action name too long - Update frog…

### DIFF
--- a/site/pages/reference/frog-composer-action.mdx
+++ b/site/pages/reference/frog-composer-action.mdx
@@ -19,12 +19,12 @@ app.composerAction( // [!code focus]
   '/', // [!code focus]
   (c) => { // [!code focus]
     return c.res({
-      title: 'My Composr Action', // [!code focus]
+      title: 'My Composer Action', // [!code focus]
       url: 'https://example.com' // [!code focus]
     }) // [!code focus]
   }, // [!code focus]
   { // [!code focus]
-    name: 'Some Composer Action', // [!code focus]
+    name: 'My Composer Action', // [!code focus]
     description: 'Cool Composer Action', // [!code focus]
     icon: 'image', // [!code focus]
     imageUrl: 'https://frog.fm/logo-light.svg', // [!code focus]
@@ -53,12 +53,12 @@ app.composerAction(
   '/', // [!code focus]
   (c) => {
     return c.res({
-      title: 'My Composr Action',
+      title: 'My Composer Action',
       url: 'https://example.com'
     })
   },
   {
-    name: 'Some Composer Action',
+    name: 'My Composer Action',
     description: 'Cool Composer Action',
     icon: 'image',
     imageUrl: 'https://frog.fm/logo-light.svg',
@@ -83,12 +83,12 @@ app.composerAction(
   '/',
   (c) => { // [!code focus]
     return c.res({ // [!code focus]
-      title: 'My Composr Action', // [!code focus]
+      title: 'My Composer Action', // [!code focus]
       url: 'https://example.com' // [!code focus]
     }) // [!code focus]
   }, // [!code focus]
   {
-    name: 'Some Composer Action',
+    name: 'My Composer Action',
     description: 'Cool Composer Action',
     icon: 'image',
     imageUrl: 'https://frog.fm/logo-light.svg',
@@ -113,12 +113,12 @@ app.composerAction(
   '/',
   (c) => {
     return c.res({
-      title: 'My Composr Action',
+      title: 'My Composer Action',
       url: 'https://example.com'
     })
   },
   { // [!code focus]
-    name: 'Some Composer Action', // [!code focus]
+    name: 'My Composer Action', // [!code focus]
     description: 'Cool Composer Action', // [!code focus]
     icon: 'image', // [!code focus]
     imageUrl: 'https://frog.fm/logo-light.svg', // [!code focus]


### PR DESCRIPTION
…-composer-action.mdx

the name of a composer action must be 14 or fewer characters

here, the default name for a composer action is 'Some Composer Action', which is 15 characters and causes the error:

Result
error
Reason
validateComposerAction 400 - Validation failed: Name must be 15 characters or less

to rectify, change the default composer action name to 'My Composer Action', which is the same as the title

also fix several known typos "Composr" -> "Composer"