### PR TITLE
Update composer-actions.mdx

### DIFF
--- a/site/pages/concepts/composer-actions.mdx
+++ b/site/pages/concepts/composer-actions.mdx
@@ -42,7 +42,7 @@ app.composerAction(
   },
   {
     /* Name of the action – 14 characters max. */
-    name: 'Some Composer Action',
+    name: 'composerAction',
     /* Description of the action – 20 characters max. */
     description: 'Cool Composer Action',
     icon: 'image',


### PR DESCRIPTION
Fixes long default composer action name

The default composer action name, "some composer action", exceeded the 14-character limit. This commit changes the name to "composerAction" to resolve this issue.