### PR TITLE
Update frog-composer-action.mdx

### DIFF
--- a/site/pages/reference/frog-composer-action.mdx
+++ b/site/pages/reference/frog-composer-action.mdx
@@ -24,7 +24,7 @@ app.composerAction( // [!code focus]
     }) // [!code focus]
   }, // [!code focus]
   { // [!code focus]
-    name: 'Some Composer Action', // [!code focus]
+    name: 'composerAction', // [!code focus]
     description: 'Cool Composer Action', // [!code focus]
     icon: 'image', // [!code focus]
     imageUrl: 'https://frog.fm/logo-light.svg', // [!code focus]
@@ -58,7 +58,7 @@ app.composerAction(
     })
   },
   {
-    name: 'Some Composer Action',
+    name: 'composerAction',
     description: 'Cool Composer Action',
     icon: 'image',
     imageUrl: 'https://frog.fm/logo-light.svg',
@@ -88,7 +88,7 @@ app.composerAction(
     }) // [!code focus]
   }, // [!code focus]
   {
-    name: 'Some Composer Action',
+    name: 'composerAction',
     description: 'Cool Composer Action',
     icon: 'image',
     imageUrl: 'https://frog.fm/logo-light.svg',
@@ -118,7 +118,7 @@ app.composerAction(
     })
   },
   { // [!code focus]
-    name: 'Some Composer Action', // [!code focus]
+    name: 'composerAction', // [!code focus]
     description: 'Cool Composer Action', // [!code focus]
     icon: 'image', // [!code focus]
     imageUrl: 'https://frog.fm/logo-light.svg', // [!code focus]


### PR DESCRIPTION
Fixes long default composer action name

The default composer action name, "some composer action", exceeded the 14-character limit. This commit changes the name to "composerAction" to resolve this issue.